### PR TITLE
Remove duplicate Contributing in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,6 @@ dotnet bite-sized \
 
 ## Contributing
 
-
-## Contributing
-
 Feature requests, bug reports *etc.* are highly welcome! Please [submit
 a new issue](https://github.com/mristin/bite-sized-csharp/issues/new).
 


### PR DESCRIPTION
This removes duplicate "Contributing" section title in the Readme.