### PR TITLE
Describe limit options in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ dotnet bite-sized \
     --exclude "**/obj/**"
 ``` 
 
+The limits can be adjusted if you are not happy with the defaults:
+
+```bash
+dotnet bite-sized \
+    --inputs "ProjectX/**/*.cs" \
+    --max-line-length 160 \
+    --max-lines-in-file 5000
+```
+
 ## Contributing
 
 Feature requests, bug reports *etc.* are highly welcome! Please [submit


### PR DESCRIPTION
The limit options can be adjusted through command line, but their
description was unintentionally omitted. This change describes their
usage in the Readme.