### PR TITLE
Support ignoring lines which match regexes

### DIFF
--- a/src/BiteSized.Test/ConsoleCapture.cs
+++ b/src/BiteSized.Test/ConsoleCapture.cs
@@ -3,7 +3,7 @@ using StringWriter = System.IO.StringWriter;
 using TextWriter = System.IO.TextWriter;
 using Console = System.Console;
 
-namespace BiteSizedCsharp.Test
+namespace BiteSized.Test
 {
     public class ConsoleCapture : IDisposable
     {

--- a/src/BiteSized.Test/TemporaryDirectory.cs
+++ b/src/BiteSized.Test/TemporaryDirectory.cs
@@ -1,6 +1,6 @@
 using IDisposable = System.IDisposable;
 
-namespace BiteSizedCsharp.Test
+namespace BiteSized.Test
 {
     class TemporaryDirectory : IDisposable
     {

--- a/src/BiteSized.Test/TestInput.cs
+++ b/src/BiteSized.Test/TestInput.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
-namespace BiteSizedCsharp.Test
+namespace BiteSized.Test
 {
     public class InputTests
     {

--- a/src/BiteSized.Test/TestInspection.cs
+++ b/src/BiteSized.Test/TestInspection.cs
@@ -1,8 +1,12 @@
 using StringReader = System.IO.StringReader;
+using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;
+using System.Linq;
+
 using NUnit.Framework;
 
-namespace BiteSizedCsharp.Test
+namespace BiteSized.Test
 {
     public class InspectionTests
     {
@@ -11,7 +15,8 @@ namespace BiteSizedCsharp.Test
         {
             using var reader = new StringReader("");
             uint maxLineLength = 120;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             Assert.AreEqual(0, record.LinesTooLong.Count);
             Assert.AreEqual(0, record.LineCount);
@@ -22,7 +27,8 @@ namespace BiteSizedCsharp.Test
         {
             using var reader = new StringReader("some content");
             uint maxLineLength = 120;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             Assert.AreEqual(0, record.LinesTooLong.Count);
             Assert.AreEqual(1, record.LineCount);
@@ -31,9 +37,11 @@ namespace BiteSizedCsharp.Test
         [Test]
         public void TestSingleLineWithTrailingNewlineOK()
         {
-            using var reader = new StringReader("some content\n");
+            var nl = System.Environment.NewLine;
+            using var reader = new StringReader($"some content{nl}");
             uint maxLineLength = 120;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             Assert.AreEqual(0, record.LinesTooLong.Count);
             Assert.AreEqual(1, record.LineCount);
@@ -44,7 +52,8 @@ namespace BiteSizedCsharp.Test
         {
             using var reader = new StringReader("1234567");
             uint maxLineLength = 3;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             var expected = new List<Inspection.LineTooLong>
             {
@@ -58,9 +67,11 @@ namespace BiteSizedCsharp.Test
         [Test]
         public void TestMultipleTrespassingLines()
         {
-            using var reader = new StringReader("123\n1234\n12345\n123");
+            var nl = System.Environment.NewLine;
+            using var reader = new StringReader($"123{nl}1234{nl}12345{nl}123");
             uint maxLineLength = 3;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             var expected = new List<Inspection.LineTooLong>
             {
@@ -73,11 +84,61 @@ namespace BiteSizedCsharp.Test
         }
 
         [Test]
+        public void TestIgnoreLinesMatching()
+        {
+            var nl = System.Environment.NewLine;
+
+            var testCases = new List<(string, string[], ulong[], string)>
+            {
+                ("AA!?", new[] {"AA"}, new ulong[]{},
+                    "line ignored"),
+
+                ($"AA--{nl}#@!?", new[] {"AA"}, new ulong[]{2},
+                    "one line ignored, other hits"),
+
+                ($"AA!?{nl}BB!?{nl}#@!?", new[] {"AA", "BB"}, new ulong[]{3},
+                    "ignored lines should match at least one pattern, one line still hits")
+            };
+
+            foreach (var (text, patterns, expectedLineTooLongs, caseName) in
+                testCases)
+            {
+                using var reader = new StringReader(text);
+                uint maxLineLength = 3;
+
+                var ignoreLinesMatching =
+                    patterns
+                    .Select(p => new Regex(p))
+                    .ToList();
+
+                Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
+
+                Assert.That(
+                    record.LinesTooLong.Select(l => l.LineNumber).ToList(),
+                    Is.EquivalentTo(expectedLineTooLongs),
+                    caseName);
+            }
+        }
+
+        [Test]
         public void TestWindowsLineCount()
         {
             using var reader = new StringReader("123\r\n123\r\n");
             uint maxLineLength = 3;
-            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength);
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
+
+            Assert.AreEqual(0, record.LinesTooLong.Count);
+            Assert.AreEqual(2, record.LineCount);
+        }
+
+        [Test]
+        public void TestLinuxLineCount()
+        {
+            using var reader = new StringReader("123\n123\n");
+            uint maxLineLength = 3;
+            var ignoreLinesMatching = new List<Regex>();
+            Inspection.Record record = Inspection.InspectLines(reader, maxLineLength, ignoreLinesMatching);
 
             Assert.AreEqual(0, record.LinesTooLong.Count);
             Assert.AreEqual(2, record.LineCount);

--- a/src/BiteSized.Test/TestOutput.cs
+++ b/src/BiteSized.Test/TestOutput.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using StringWriter = System.IO.StringWriter;
 using NUnit.Framework;
 
-namespace BiteSizedCsharp.Test
+namespace BiteSized.Test
 {
     public class OutputTests
     {

--- a/src/BiteSized/BiteSized.csproj
+++ b/src/BiteSized/BiteSized.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>1.0.0-beta1</Version>
+        <Version>1.0.0-beta2</Version>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>bite-sized</ToolCommandName>
     </PropertyGroup>

--- a/src/BiteSized/Input.cs
+++ b/src/BiteSized/Input.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Path = System.IO.Path;
 using System.Linq;
 
-namespace BiteSizedCsharp
+namespace BiteSized
 {
     public static class Input
     {

--- a/src/BiteSized/Inspection.cs
+++ b/src/BiteSized/Inspection.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using TextReader = System.IO.TextReader;
+using ArgumentException = System.ArgumentException;
+using Regex = System.Text.RegularExpressions.Regex;
 
-namespace BiteSizedCsharp
+namespace BiteSized
 {
     public static class Inspection
     {
@@ -50,8 +52,9 @@ namespace BiteSizedCsharp
         /// </summary>
         /// <param name="reader">Reads the source file</param>
         /// <param name="maxLineLength">maximum allowed line length</param>
+        /// <param name="ignoreLinesMatching">ignore all lines matching one of the regular expressions</param>
         /// <returns>List of problematic comments</returns>
-        public static Record InspectLines(TextReader reader, uint maxLineLength)
+        public static Record InspectLines(TextReader reader, uint maxLineLength, List<Regex> ignoreLinesMatching)
         {
             var linesTooLong = new List<LineTooLong>(1024);
             ulong lineCount = 0;
@@ -59,7 +62,9 @@ namespace BiteSizedCsharp
             string? line;
             while ((line = reader.ReadLine()) != null)
             {
-                if (line.Length > maxLineLength)
+                bool ignored = ignoreLinesMatching.Exists((regex) => regex.IsMatch(line));
+
+                if (!ignored && line.Length > maxLineLength)
                 {
                     linesTooLong.Add(new LineTooLong(lineCount + 1, (uint)line.Length));
                 }

--- a/src/BiteSized/Output.cs
+++ b/src/BiteSized/Output.cs
@@ -1,7 +1,7 @@
 using System;
 using TextWriter = System.IO.TextWriter;
 
-namespace BiteSizedCsharp
+namespace BiteSized
 {
     public static class Output
     {


### PR DESCRIPTION
This enhancement adds an option to allow for ignoring lines which match
one of the regular expressions.

This is important if you can not break certain strings (such as URLs)
in your files, but still want to maintain a general limit on line
length.