### PR TITLE
Improve error reporting at the end of a scan

### DIFF
--- a/src/BiteSized.Test/TestProgram.cs
+++ b/src/BiteSized.Test/TestProgram.cs
@@ -82,7 +82,7 @@ namespace BiteSized.Test
                 $"  * The file is too long. It contains 2 line(s), but only 1 line(s) are allowed.{nl}",
                 consoleCapture.Output());
 
-            Assert.AreEqual("", consoleCapture.Error());
+            Assert.AreEqual($"One or more input files failed the checks.{nl}", consoleCapture.Error());
         }
 
         [Test]
@@ -142,10 +142,11 @@ namespace BiteSized.Test
                 $"FAIL {path}{nl}" +
                 $"  * The following line(s) have more than allowed 3 characters:{nl}" +
                 $"    * Line 1: 5 characters{nl}" +
-                $"    * Line 3: 6 characters{nl}",
+                $"    * Line 3: 6 characters{nl}" +
+                $"The --ignore-lines-matching was set to: ^AAA{nl}",
                 consoleCapture.Output());
 
-            Assert.AreEqual("", consoleCapture.Error());
+            Assert.AreEqual($"One or more input files failed the checks.{nl}", consoleCapture.Error());
         }
     }
 }

--- a/src/BiteSized.sln.DotSettings.user
+++ b/src/BiteSized.sln.DotSettings.user
@@ -1,0 +1,8 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=5d7fde8f_002Da879_002D4e9b_002D984d_002Df1c28e2ec90e/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="InspectionTests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::2A5C6C3B-BFBC-4C10-9D1E-7494EDB99EFD::.NETCoreApp,Version=v3.1::BiteSized.Test.InspectionTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::2A5C6C3B-BFBC-4C10-9D1E-7494EDB99EFD::.NETCoreApp,Version=v3.1::BiteSized.Test.ProgramTests.TestIgnoreLinesMatching&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::2A5C6C3B-BFBC-4C10-9D1E-7494EDB99EFD::.NETCoreApp,Version=v3.1::BiteSized.Test.ProgramTests&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
If you use bite-sized in a continuous integration (CI) programatically,
it is useful to see what the options were set on failures. This makes it
easier for the user to immediately see the cause of the errors rather
than having to dig into the CI scripts.