### PR TITLE
Remove trailing whitespace in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,30 @@ https://www.nuget.org/packages/BiteSized
 )
 
 
-Bite-sized is a dotnet tool to check that your source code is not too long 
+Bite-sized is a dotnet tool to check that your source code is not too long
 (number of lines) and not too wide (number of characters per line).
 
 ## Motivation
 
-It would be great if we could decouple our source code from its visual 
-representation and stop treating it like text (*e.g.*, diff'ing two files 
+It would be great if we could decouple our source code from its visual
+representation and stop treating it like text (*e.g.*, diff'ing two files
 *as code* regardless of formatting). Unfortunately, our development
 environments are not there yet and we still rely heavily on tools that treat
-the source code as *text*. Hence, we need to use tools that are unable to 
+the source code as *text*. Hence, we need to use tools that are unable to
 automatically wrap and reformat the code on the spot. This forces us to deal
 with issues unless we enforce line and character limits.
- 
-**Maximum line width** is important so that:
-* You can compare 2 or 3 files in parallel or view them without tedious 
-  horizontal scrolls. For example, Github layout will expect all source code to 
-  be within a certain width (and force you to horizontally scroll otherwise).
-* Furthermore, the developers using laptops or people who need to display or 
-  print your code will really appreciate it.
-* Finally, short lines force you to be succinct to a certain degree and 
-  long lines might signal that your code is too stuffed. Humans need width 
-  limits for parsing (hence the layout of the books!). 
 
-The limit of 120 characters is perhaps a nice compromise between wide-enough 
+**Maximum line width** is important so that:
+* You can compare 2 or 3 files in parallel or view them without tedious
+  horizontal scrolls. For example, Github layout will expect all source code to
+  be within a certain width (and force you to horizontally scroll otherwise).
+* Furthermore, the developers using laptops or people who need to display or
+  print your code will really appreciate it.
+* Finally, short lines force you to be succinct to a certain degree and
+  long lines might signal that your code is too stuffed. Humans need width
+  limits for parsing (hence the layout of the books!).
+
+The limit of 120 characters is perhaps a nice compromise between wide-enough
 lines (no unnecessary line breaks) and reading experience.
 
 **Maximum number of lines** is a good proxy of complexity. Once you pass a
@@ -44,15 +44,15 @@ certain threshold, problems start to surface:
   the `using`s in your long C# file that will clutter the symbol space).
 * Long files are a potential indicator that the level of abstraction is not
   adequate anymore.
-* Your tests will be conceptually blurry if you relate them to long files 
+* Your tests will be conceptually blurry if you relate them to long files
   (*i.e.* many tests lumped together).
-* Your commit log is loosing precision as file changes will not be that 
+* Your commit log is loosing precision as file changes will not be that
   informative any more.
 * ... and many, many more problems.
 
-Beware that this limit should not be too strict lest it gives you fragmented 
+Beware that this limit should not be too strict lest it gives you fragmented
 code (which is equally bad for the readability!). A reasonable maximum length
-might be about 2000 lines. 
+might be about 2000 lines.
 
 ## Related Tools
 
@@ -65,7 +65,7 @@ https://www.jetbrains.com/help/resharper/ReSharper_Command_Line_Tools.html
 
 * Another code inspector, [StyleCop](
 https://github.com/StyleCop/StyleCop
-) supports the maximum number of lines and characters, but the tool is not 
+) supports the maximum number of lines and characters, but the tool is not
 actively maintained anymore (see [this section in their readme](
 https://github.com/StyleCop/StyleCop#considerations
 )).
@@ -82,7 +82,7 @@ https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/782#issuecomment-140
 https://github.com/menees/Analyzers) that can verify the line number and length.
 Unfortunately, it is not a dotnet tool (it requires .NET Framework, see
 [this comment on the Github issue](
-https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/782) and 
+https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/782) and
 [this comment](
 https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/782#issuecomment-243275140
 )).
@@ -118,14 +118,14 @@ You specify which files need to be checked using glob patterns in `--inputs`:
 dotnet bite-sized --inputs "ProjectX/**/*.cs"
 ```
 
-You exclude by passing `--excludes` with glob patterns  
+You exclude by passing `--excludes` with glob patterns
 *(we use '\' for line continuation here)*:
 
 ```bash
 dotnet bite-sized \
     --inputs "ProjectX/**/*.cs" \
     --exclude "**/obj/**"
-``` 
+```
 
 The limits can be adjusted if you are not happy with the defaults:
 


### PR DESCRIPTION
The trailing whitespace is removed in Readme to make future diffs
easier to follow.