### PR TITLE
Introduce `--verbose` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Options:
   --ignore-lines-matching <ignore-lines-matching>    Ignore lines matching the regular expression(s)
   --max-line-length <max-line-length>                Maximum allowed line length [default: 120]
   --max-lines-in-file <max-lines-in-file>            Maximum number of lines allowed in a file [default: 2000]
+  --verbose                                          If set, displays the result for each individual file; otherwise, shows only errors
   --version                                          Show version information
   -?, -h, --help                                     Show help and usage information
 ```

--- a/src/BiteSized.Test/TestOutput.cs
+++ b/src/BiteSized.Test/TestOutput.cs
@@ -8,7 +8,7 @@ namespace BiteSized.Test
     public class OutputTests
     {
         [Test]
-        public void TestOK()
+        public void TestOKWithVerbose()
         {
             using var writer = new StringWriter();
 
@@ -16,10 +16,25 @@ namespace BiteSized.Test
                 new List<Inspection.LineTooLong>(),
                 10);
 
-            Output.Report("Program.cs", record, 13, 1984, writer);
+            Output.Report("Program.cs", record, 13, 1984, true, writer);
 
             var nl = Environment.NewLine;
             Assert.AreEqual($"OK   Program.cs{nl}", writer.ToString());
+        }
+
+        [Test]
+        public void TestOKWithoutVerbose()
+        {
+            using var writer = new StringWriter();
+
+            var record = new Inspection.Record(
+                new List<Inspection.LineTooLong>(),
+                10);
+
+            Output.Report("Program.cs", record, 13, 1984, false, writer);
+
+            var nl = Environment.NewLine;
+            Assert.AreEqual("", writer.ToString());
         }
 
         [Test]
@@ -34,7 +49,7 @@ namespace BiteSized.Test
                 },
                 10);
 
-            Output.Report("Program.cs", record, 13, 1984, writer);
+            Output.Report("Program.cs", record, 13, 1984, false, writer);
 
             var nl = Environment.NewLine;
             string expected = $"FAIL Program.cs{nl}" +
@@ -58,7 +73,7 @@ namespace BiteSized.Test
                 },
                 10);
 
-            Output.Report("Program.cs", record, 13, 1984, writer);
+            Output.Report("Program.cs", record, 13, 1984, false, writer);
 
             var nl = Environment.NewLine;
             string expected = $"FAIL Program.cs{nl}" +
@@ -79,7 +94,7 @@ namespace BiteSized.Test
                 new List<Inspection.LineTooLong>(),
                 5000);
 
-            Output.Report("Program.cs", record, 13, 1984, writer);
+            Output.Report("Program.cs", record, 13, 1984, false, writer);
 
             var nl = Environment.NewLine;
             string expected = $"FAIL Program.cs{nl}" +
@@ -102,7 +117,7 @@ namespace BiteSized.Test
                 },
                 5000);
 
-            Output.Report("Program.cs", record, 13, 1984, writer);
+            Output.Report("Program.cs", record, 13, 1984, false, writer);
 
             var nl = Environment.NewLine;
             string expected = $"FAIL Program.cs{nl}" +

--- a/src/BiteSized.Test/TestProgram.cs
+++ b/src/BiteSized.Test/TestProgram.cs
@@ -46,7 +46,7 @@ namespace BiteSized.Test
 
             using var consoleCapture = new ConsoleCapture();
 
-            int exitCode = Program.MainWithCode(new[] { "--inputs", path });
+            int exitCode = Program.MainWithCode(new[] { "--inputs", path, "--verbose" });
 
             string nl = Environment.NewLine;
 
@@ -102,7 +102,9 @@ namespace BiteSized.Test
                 new[] {
                     "--inputs", Path.Join(tmpdir.Path, "Included*.cs"),
                     "--excludes", Path.Join(tmpdir.Path, "Excluded*.cs"),
-                    "--max-line-length", "3", "--max-lines-in-file", "1" });
+                    "--max-line-length", "3", "--max-lines-in-file", "1",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 

--- a/src/BiteSized/Output.cs
+++ b/src/BiteSized/Output.cs
@@ -15,7 +15,7 @@ namespace BiteSized
         /// <param name="writer">Writes the report</param>
         /// <returns>true if no trespasses</returns>
         public static bool Report(string path, Inspection.Record record,
-            uint maxLineLength, ulong maxLinesInFile, TextWriter writer)
+            uint maxLineLength, ulong maxLinesInFile, bool verbose, TextWriter writer)
         {
             ////
             // Precondition(s)
@@ -38,7 +38,11 @@ namespace BiteSized
 
             if (record.LinesTooLong.Count == 0 && record.LineCount <= maxLinesInFile)
             {
-                writer.WriteLine($"OK   {path}");
+                if (verbose)
+                {
+                    writer.WriteLine($"OK   {path}");
+                }
+
                 return true;
             }
 

--- a/src/BiteSized/Program.cs
+++ b/src/BiteSized/Program.cs
@@ -26,6 +26,7 @@ namespace BiteSized
             public string[]? IgnoreLinesMatching { get; set; }
             public uint MaxLineLength { get; set; }
             public uint MaxLinesInFile { get; set; }
+            public bool Verbose { get; set; }
             // ReSharper restore CollectionNeverUpdated.Global
             // ReSharper restore UnusedAutoPropertyAccessor.Global
 #pragma warning restore 8618
@@ -61,7 +62,7 @@ namespace BiteSized
                 using StreamReader sr = File.OpenText(path);
                 var record = Inspection.InspectLines(sr, a.MaxLineLength, ignoreLinesMatching);
 
-                bool isOk = Output.Report(path, record, a.MaxLineLength, a.MaxLinesInFile, Console.Out);
+                bool isOk = Output.Report(path, record, a.MaxLineLength, a.MaxLinesInFile, a.Verbose, Console.Out);
                 success = success & isOk;
             }
 
@@ -108,7 +109,12 @@ namespace BiteSized
                 new Option<uint>(
                     "--max-lines-in-file",
                     () => 2000,
-                    "Maximum number of lines allowed in a file")
+                    "Maximum number of lines allowed in a file"),
+
+
+                new Option<bool>(
+                    "--verbose",
+                    "If set, displays the result for each individual file; otherwise, shows only errors")
             };
 
             rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create((Arguments a) => Handle(a));


### PR DESCRIPTION
It is tedious for the user to fish through a long output when running
BiteSized on a large code base.

This patch introduces the `--verbose` flag so that the user sees only
errors by default, and the long list of OK's is hidden.