### PR TITLE
Update to net6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.100'
+          dotnet-version: '6.x'
 
       - name: Restore dotnet tools
         working-directory: src

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "deadcsharp": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "commands": [
         "dead-csharp"
       ]

--- a/src/BiteSized.Test/BiteSized.Test.csproj
+++ b/src/BiteSized.Test/BiteSized.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/BiteSized/BiteSized.csproj
+++ b/src/BiteSized/BiteSized.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>1.0.1</Version>
         <PackAsTool>true</PackAsTool>

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -11,7 +11,7 @@ function Main
     Set-Location $PSScriptRoot
 
     Write-Host "Checking the format..."
-    dotnet format --check
+    dotnet format --verify-no-changes
     if ($LASTEXITCODE -ne 0)
     {
         throw "Format check failed."


### PR DESCRIPTION
Net6 is the current LTS version, supported until November 2024.
https://dotnet.microsoft.com/en-us/download/dotnet

My goal is to get doctest-csharp updated to net6 (so I can use it
without installing .net3.1 runtime). To do that and keep the CI
builds running successfully, this project (bite-sized-csharp) needs updated.