### PR TITLE
Upgrade coveralls.net to latest

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "coveralls.net": {
-      "version": "2.0.0",
+      "version": "4.0.0",
       "commands": [
         "csmacnz.Coveralls"
       ]


### PR DESCRIPTION
We need to upgrade the package coveralls.net to 4.0.0 so that it runs
under Net6.