### PR TITLE
Upgrade to net6 in publish action

### DIFF
--- a/.github/workflows/generate-nuget.yml
+++ b/.github/workflows/generate-nuget.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.100'
+          dotnet-version: '6.x'
 
       - name: Build solution and generate NuGet package
         working-directory: src


### PR DESCRIPTION
We need to upgrade to net6 since the publish action needs to build the
code.